### PR TITLE
Destaca rota atual conforme os itens do menu

### DIFF
--- a/files/Sidebar.vemtl
+++ b/files/Sidebar.vemtl
@@ -53,7 +53,7 @@
                 <% if(this.generatorSettings.modules.permissions) { %>
                 @if (Auth::user()->can('view-any', Spatie\Permission\Models\Role::class) || 
                     Auth::user()->can('view-any', Spatie\Permission\Models\Permission::class))
-                <li class="nav-item">
+                <li class="nav-item @if(Route::is(['roles.*','permissions.*'])) menu-open @endif">
                     <a href="#" class="nav-link">
                         <i class="nav-icon icon ion-md-key"></i>
                         <p>
@@ -64,7 +64,7 @@
                     <ul class="nav nav-treeview">
                         @can('view-any', Spatie\Permission\Models\Role::class)
                         <li class="nav-item">
-                            <a href="{{ route('roles.index') }}" class="nav-link">
+                            <a href="{{ route('roles.index') }}" class="nav-link @if(Route::is('roles.*')) active @endif">
                                 <i class="nav-icon icon ion-md-radio-button-off"></i>
                                 <p>Roles</p>
                             </a>
@@ -73,7 +73,7 @@
 
                         @can('view-any', Spatie\Permission\Models\Permission::class)
                         <li class="nav-item">
-                            <a href="{{ route('permissions.index') }}" class="nav-link">
+                            <a href="{{ route('permissions.index') }}" class="nav-link @if(Route::is('permissions.*')) active @endif">
                                 <i class="nav-icon icon ion-md-radio-button-off"></i>
                                 <p>Permissions</p>
                             </a>

--- a/files/Sidebar.vemtl
+++ b/files/Sidebar.vemtl
@@ -40,7 +40,7 @@
                         <% for(let crud of this.project.getMainCruds()) { %>
                             @can('view-any', <$ this.projectHelper.getModelsNamespace() $>\<$ crud.model.name $>::class)
                             <li class="nav-item">
-                                <a href="{{ route('<$ crud.model.plural.case('paramCase') $>.index') }}" class="nav-link">
+                                <a href="{{ route('<$ crud.model.plural.case('paramCase') $>.index') }}" class="nav-link @if(Route::is('<$ crud.model.plural.case('paramCase') $>.*')) active @endif">
                                     <i class="nav-icon icon ion-md-radio-button-off"></i>
                                     <p><$ crud.name $></p>
                                 </a>

--- a/files/Sidebar.vemtl
+++ b/files/Sidebar.vemtl
@@ -23,7 +23,12 @@
                     </a>
                 </li>
 
-                <li class="nav-item">
+                <li class="nav-item @if(Route::is([
+                        <% for(let crud of this.project.getMainCruds()) { %>
+                              '<$ crud.model.plural.case('paramCase') $>.*',
+                        <% } %>
+                      ])) menu-open @endif"
+                >
                     <a href="#" class="nav-link">
                         <i class="nav-icon icon ion-md-apps"></i>
                         <p>


### PR DESCRIPTION
Compara as rotas do menu com a rota atual para expandir e ativar o item de menu correspondente

![image](https://user-images.githubusercontent.com/17914565/202871658-1086837a-e84f-4118-a9fa-24767e9ab98d.png)
